### PR TITLE
Don't try to serialize default DateTime

### DIFF
--- a/src/Couchbase.Lite.Mapping/Couchbase.Lite.Mapping.csproj
+++ b/src/Couchbase.Lite.Mapping/Couchbase.Lite.Mapping.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Couchbase.Lite.Mapping/ObjectExtensions.cs
+++ b/src/Couchbase.Lite.Mapping/ObjectExtensions.cs
@@ -103,9 +103,11 @@ namespace Couchbase.Lite
             {
                 dictionary[propertyName] = new Blob(string.Empty, (byte[])propertyValue);
             }
-            else if (propertyType == typeof(DateTime) || propertyType == typeof(DateTime?))
-            {
-                dictionary[propertyName] = new DateTimeOffset((DateTime)propertyValue);
+            else if (propertyType == typeof(DateTime) || propertyType == typeof(DateTime?)) {
+                var dateTimeVal = ((DateTime) propertyValue);
+                if (dateTimeVal != default(DateTime)) {
+                    dictionary[propertyName] = new DateTimeOffset((DateTime) propertyValue);
+                }
             }
             else if (!propertyType.IsSimple() && !propertyType.IsEnum && propertyType.IsClass && propertyValue != null)
             {


### PR DESCRIPTION
If the timezone is after GMT it will underflow (note that a sufficiently low DateTime will still underflow.  Moral:  USE DATETIMEOFFSET!)  Fixes #21