### PR TITLE
Fix failing unit tests

### DIFF
--- a/src/Couchbase.Lite.Mapping.Shared.Tests/PropertyNameConversionTests.cs
+++ b/src/Couchbase.Lite.Mapping.Shared.Tests/PropertyNameConversionTests.cs
@@ -14,6 +14,8 @@ namespace Couchbase.Lite.Mapping.Tests
                 StringValue = "Test Value"
             };
 
+            Settings.PropertyNameConverter = null;
+
             var mutableDocument = simpleObject.ToMutableDocument();
 
             var result = mutableDocument?.Keys.Contains("stringValue");

--- a/src/Couchbase.Lite.Mapping/ObjectExtensions.cs
+++ b/src/Couchbase.Lite.Mapping/ObjectExtensions.cs
@@ -105,7 +105,11 @@ namespace Couchbase.Lite
             }
             else if (propertyType == typeof(DateTime) || propertyType == typeof(DateTime?))
             {
-                dictionary[propertyName] = new DateTimeOffset((DateTime)propertyValue);
+                DateTime dateTimePropertyValue = (DateTime)propertyValue;
+                DateTimeOffset dateTimeOffset = dateTimePropertyValue.ToUniversalTime() <= DateTimeOffset.MinValue.UtcDateTime
+                                                ? DateTimeOffset.MinValue
+                                                : new DateTimeOffset(dateTimePropertyValue);
+                dictionary[propertyName] = dateTimeOffset;
             }
             else if (!propertyType.IsSimple() && !propertyType.IsEnum && propertyType.IsClass && propertyValue != null)
             {


### PR DESCRIPTION
Forcing Settings.PropertyNameConverter to null
Set MinValue of DateTimeOffset when out of range